### PR TITLE
Update upload.js

### DIFF
--- a/src/server/routes/api/upload.js
+++ b/src/server/routes/api/upload.js
@@ -8,6 +8,7 @@ const colors = require('colors');
 
 const { Router } = require('express');
 const { existsSync, mkdirSync } = require('fs');
+const path = require('path');
 
 const { getUserFromKey, addUserUpload, saveFile, setUserDomain, setUserSubDomain } = require('../../../database/index');
 const { filePOST } = require('../../../util/logger');
@@ -24,7 +25,9 @@ router.use(limiter);
 const fileUpload = require('express-fileupload');
 router.use(fileUpload({
     safeFileNames: true,
-    preserveExtension: true,
+    preserveExtension: 7,
+    useTempFiles: true,
+    tempFileDir: path.resolve(__dirname + '../../../temp/'),
     limits: {
         fileSize: config.maxFileSize || 9007199254740991
     }


### PR DESCRIPTION
fix preserveExtension as `true` most likely breaks formats such as `.jpeg` and fix a crash vulnerability by putting files to temp folder instead of memory (crash vulnerability for big files as uploading 1gb file would make the server use 1gb ram)